### PR TITLE
入力後でもボタンが効かない不具合を修正

### DIFF
--- a/ReMember/ViewController/RegistrationViewController.swift
+++ b/ReMember/ViewController/RegistrationViewController.swift
@@ -26,7 +26,7 @@ class RegistrationViewController: UIViewController, UIImagePickerControllerDeleg
     @IBOutlet var dateFiled: UITextField!
     @IBOutlet var comformButton: MDCButton!
     
-    
+    private let alertMessage = MDCSnackbarMessage()
     let fsRegstration = FirestoreResistration()
     
     private var profImage: UIImage?
@@ -91,9 +91,22 @@ class RegistrationViewController: UIViewController, UIImagePickerControllerDeleg
     
     // 登録ボタン押した時
     @IBAction func store(){
-        guard let name = nameField.text else {return}
-        guard let date = inputDate else { return }
-        guard let img = profImage else { return }
+        guard let name = nameField.text else {
+            alertMessage.text = "名前が入力されていません"
+            MDCSnackbarManager.show(alertMessage)
+            return
+        }
+        guard let date = inputDate else {
+            alertMessage.text = "命日が入力されていません"
+            MDCSnackbarManager.show(alertMessage)
+            return
+        }
+        guard let img = profImage else {
+            alertMessage.text = "写真を登録してください"
+            MDCSnackbarManager.show(alertMessage)
+            return
+        }
+        
         loadingAnimationView.animation = Animation.named("animation-w400-h300")
         loadingAnimationView.loopMode = .loop
         loadingAnimationView.play()
@@ -179,10 +192,6 @@ extension RegistrationViewController: UITextFieldDelegate {
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
         
         if nameField.text == "" {
-            return true
-        }
-        
-        if dateFiled.text == "" {
             return true
         }
         


### PR DESCRIPTION
## 変更点
* 名前を入力したらボタンが押せるように変更
* 未入力の際にどれが未入力かどうかをアラートで知らせるようにした

## 変更理由
登録画面で必要事項を記入してもボタンが未入力の状態で登録することができなかったため
DatePickerは入力完了後にTextFieldに反映されるため，TextFieldの入力チェックから漏れていた．

## 対応Issue
#7 